### PR TITLE
fix: Adjust command syntax for running locally

### DIFF
--- a/docs/building-spokane-tech/part-03.md
+++ b/docs/building-spokane-tech/part-03.md
@@ -59,7 +59,7 @@ cd src/django_project
 
 ### Create a local database by running django migrations
 ```
-python./manage.py migrate
+python ./manage.py migrate
 ```
 
 ### Create a local admin user

--- a/docs/building-spokane-tech/part-03.md
+++ b/docs/building-spokane-tech/part-03.md
@@ -38,7 +38,7 @@ venv\Scripts\activate
 
 ### Install the python dependencies
 ```
-pip install .[dev]
+pip install '.[dev]'
 ```
 
 ### Install playwright dependencies 


### PR DESCRIPTION
# Description

I spotted 2 opportunities for improvement on the [running local page](https://spokanetech.github.io/blog/building-spokane-tech/part-03/)

1. Missing space on the command for 'Create a local database by running django migrations' section - https://github.com/SpokaneTech/blog/commit/f4c3f266ce5101fa9fe6ce8a44363135d7e49f2c
2. Quoting the `.[dev]` on the 'Install the python dependencies' section. I got an error due to my shell interpreting it as glob pattern. - https://github.com/SpokaneTech/blog/commit/c0c64b3659f87e3b78fdc03b329c2c71064f2dae


